### PR TITLE
Revert "updated to eclipse-parent 0.9.1 to fix checkstyle build failure"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.1</version>
+		<version>0.9.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.emf-profiles</groupId>
 	<artifactId>parent</artifactId>	


### PR DESCRIPTION
Reverts PalladioSimulator/Palladio-ThirdParty-EMFProfiles#9